### PR TITLE
Fix response object in get list predictions

### DIFF
--- a/prediction.go
+++ b/prediction.go
@@ -36,7 +36,7 @@ type Prediction struct {
 
 // Predictions represents list of Prediction object.
 type Predictions struct {
-	Images []Prediction `json:"images"`
+	Images []Prediction `json:"image"`
 }
 
 // PredictionData refers to Prediction object.

--- a/testdata/predictions.json
+++ b/testdata/predictions.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "images": [
+    "image": [
       {
         "id": "5a44671ab3957c2ab5c33326",
         "answer": "approved",


### PR DESCRIPTION
Kind of weird that response object of Get List Predictions is not be the same as others.

This changes fix response object following manual test against prod.