### PR TITLE
Update Kiyo-Image host url

### DIFF
--- a/actions/choice.go
+++ b/actions/choice.go
@@ -75,19 +75,19 @@ type PostChoice struct {
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image
 // Choice API.
 func (*GetChoice) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/choice"
+	return config.KiyoImageAPIURL, "GET", "/api/images/choice"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Choice API.
 func (*GetChoices) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/choices"
+	return config.KiyoImageAPIURL, "GET", "/api/images/choices"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Choice API.
 func (*PostChoice) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", "/api/images/choices"
+	return config.KiyoImageAPIURL, "POST", "/api/images/choices"
 }
 
 // Payload creates request's payload for Get Image Choice API. Returns http.Request object

--- a/actions/choice_test.go
+++ b/actions/choice_test.go
@@ -11,7 +11,7 @@ func TestPostChoiceEndpoint(t *testing.T) {
 	p := &PostChoice{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetChoicesEndpoint(t *testing.T) {
 	g := &GetChoices{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestGetChoiceEndpoint(t *testing.T) {
 	g := &GetChoice{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)

--- a/actions/closed_question.go
+++ b/actions/closed_question.go
@@ -72,19 +72,19 @@ type PostClosedQuestion struct {
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image
 // Closed Question API.
 func (*GetClosedQuestion) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/closed_question"
+	return config.KiyoImageAPIURL, "GET", "/api/images/closed_question"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Closed Question API.
 func (*GetClosedQuestions) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/closed_questions"
+	return config.KiyoImageAPIURL, "GET", "/api/images/closed_questions"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Closed Question API.
 func (*PostClosedQuestion) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", "/api/images/closed_questions"
+	return config.KiyoImageAPIURL, "POST", "/api/images/closed_questions"
 }
 
 // Payload creates request's payload for Get Image Closed Question API. Returns http.Request

--- a/actions/closed_question_test.go
+++ b/actions/closed_question_test.go
@@ -11,7 +11,7 @@ func TestGetClosedQuestionEndpoint(t *testing.T) {
 	g := &GetClosedQuestion{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetListClosedQuestionEndpoint(t *testing.T) {
 	g := &GetClosedQuestions{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestPostCloseQuestionEndpoint(t *testing.T) {
 	p := &PostClosedQuestion{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)

--- a/actions/image.go
+++ b/actions/image.go
@@ -32,7 +32,7 @@ type GetImage struct {
 
 // Endpoint returns Get Image request url, verb and endpoint
 func (*GetImage) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/projects/images"
+	return config.KiyoImageAPIURL, "GET", "/api/projects/images"
 }
 
 // Payload creates request's payload for Get Image API. Returns http.Request object.

--- a/actions/image_check.go
+++ b/actions/image_check.go
@@ -72,19 +72,19 @@ type PostImageCheck struct {
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image
 // Check API.
 func (*GetImageCheck) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", Path
+	return config.KiyoImageAPIURL, "GET", Path
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Check API.
 func (*GetImageChecks) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", Path
+	return config.KiyoImageAPIURL, "GET", Path
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Check API.
 func (*PostImageCheck) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", Path
+	return config.KiyoImageAPIURL, "POST", Path
 }
 
 // Payload creates request's payload for Get Image Check API. Returns http.Request

--- a/actions/image_check_test.go
+++ b/actions/image_check_test.go
@@ -11,7 +11,7 @@ func TestGetImageCheckEndpoint(t *testing.T) {
 	g := &GetImageCheck{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetListImageCheckEndpoint(t *testing.T) {
 	g := &GetImageChecks{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestPostImageCheckEndpoint(t *testing.T) {
 	p := &PostImageCheck{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)

--- a/actions/image_test.go
+++ b/actions/image_test.go
@@ -11,7 +11,7 @@ func TestGetImageEndpoint(t *testing.T) {
 	g := &GetImage{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)

--- a/actions/message.go
+++ b/actions/message.go
@@ -72,19 +72,19 @@ type PostMessage struct {
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image Message API.
 func (*GetMessage) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/message"
+	return config.KiyoImageAPIURL, "GET", "/api/images/message"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Message API.
 func (*GetMessages) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/messages"
+	return config.KiyoImageAPIURL, "GET", "/api/images/messages"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Message API.
 func (*PostMessage) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", "/api/images/messages"
+	return config.KiyoImageAPIURL, "POST", "/api/images/messages"
 }
 
 // Payload creates request's payload for Get Image Message API. Returns http.Request object

--- a/actions/message_test.go
+++ b/actions/message_test.go
@@ -11,7 +11,7 @@ func TestGetMessagesEndpoint(t *testing.T) {
 	g := &GetMessages{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetMessageEndpoint(t *testing.T) {
 	g := &GetMessage{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestPostMessage(t *testing.T) {
 	p := &PostMessage{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)

--- a/actions/photo_tag.go
+++ b/actions/photo_tag.go
@@ -73,19 +73,19 @@ type PostPhotoTag struct {
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image
 // Photo Tag API.
 func (*GetPhotoTag) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/photo_tag"
+	return config.KiyoImageAPIURL, "GET", "/api/images/photo_tag"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Photo Tag API.
 func (*GetPhotoTags) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/images/photo_tags"
+	return config.KiyoImageAPIURL, "GET", "/api/images/photo_tags"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Photo Tag API.
 func (*PostPhotoTag) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", "/api/images/photo_tags"
+	return config.KiyoImageAPIURL, "POST", "/api/images/photo_tags"
 }
 
 // Payload creates request's payload for Get Image Photo Tag API. Returns http.Request object

--- a/actions/photo_tag_test.go
+++ b/actions/photo_tag_test.go
@@ -11,7 +11,7 @@ func TestGetPhotoTagEndpoint(t *testing.T) {
 	g := &GetPhotoTag{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetPhotoTagsPayload(t *testing.T) {
 	g := &GetPhotoTags{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestPostPhotoTag(t *testing.T) {
 	p := &PostPhotoTag{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)

--- a/actions/prediction.go
+++ b/actions/prediction.go
@@ -68,19 +68,19 @@ type PostPrediction struct {
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get Image
 // Prediction API.
 func (*GetPrediction) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/prime/predictions"
+	return config.KiyoImageAPIURL, "GET", "/api/prime/predictions"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Get list of
 // Image Prediction API.
 func (*GetPredictions) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "GET", "/api/prime/predictions"
+	return config.KiyoImageAPIURL, "GET", "/api/prime/predictions"
 }
 
 // Endpoint returns K Sequencing's request url, verb and endpoint for calling Create Image
 // Prediction API.
 func (*PostPrediction) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "POST", "/api/prime/predictions"
+	return config.KiyoImageAPIURL, "POST", "/api/prime/predictions"
 }
 
 // Payload creates request's payload for Get Image Prediction API. Returns http.Request object.

--- a/actions/prediction_test.go
+++ b/actions/prediction_test.go
@@ -11,7 +11,7 @@ func TestGetPredictionTagEndpoint(t *testing.T) {
 	g := &GetPrediction{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -22,7 +22,7 @@ func TestGetPredictionsPayload(t *testing.T) {
 	g := &GetPredictions{}
 	endpoint, method, path := g.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "GET", method)
 	a.NotNil(t, path)
@@ -33,7 +33,7 @@ func TestPostPrediction(t *testing.T) {
 	p := &PostPrediction{}
 	endpoint, method, path := p.Endpoint()
 	a.NotNil(t, endpoint)
-	a.Equal(t, config.KSeqAPIURL, endpoint)
+	a.Equal(t, config.KiyoImageAPIURL, endpoint)
 	a.NotNil(t, method)
 	a.Equal(t, "POST", method)
 	a.NotNil(t, path)

--- a/client_test.go
+++ b/client_test.go
@@ -33,7 +33,7 @@ type mockPayload struct {
 }
 
 func (*mockPayload) Endpoint() (string, string, string) {
-	return config.KSeqAPIURL, "method", "path"
+	return config.KiyoImageAPIURL, "method", "path"
 }
 
 func (m *mockPayload) Payload(endpoint, method, path string) (*http.Request, error) {

--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -1,8 +1,8 @@
 package config
 
 const (
-	// KSeqAPIURL represents the K-Sequencing endpoint API.
-	KSeqAPIURL string = "https://k-sequencing.datawow.io"
+	// KiyoImageAPIURL represents the Kiyo-Image endpoint API.
+	KiyoImageAPIURL string = "https://kiyo-image.datawow.io"
 	// KiyoTextAPIURL represents the Kiyo-Text endpoint API
 	KiyoTextAPIURL string = "https://kiyo-text.datawow.io"
 )


### PR DESCRIPTION
This PR changes host URL of Kiyo-Image from deprecated one, https://k-sequencing.datawow.io to https://kiyo-image.datawow.io